### PR TITLE
Pad the operands in evalBinOp to work w/ops that lex like an identifier

### DIFF
--- a/zaphod/chrome/content/narcissus/jsexec.js
+++ b/zaphod/chrome/content/narcissus/jsexec.js
@@ -309,7 +309,7 @@ Narcissus.interpreter = (function() {
 
     function evalBinOp(v1, v2, x, op) {
         return evaluateEachPair(v1, v2, function(v1, v2) {
-            return eval('v1' + op + 'v2');
+            return eval('v1 ' + op + ' v2');
         }, x);
     }
 


### PR DESCRIPTION
When op = in, this runs eval('v1' + 'in' + 'v1') === eval('v1inv2')
A similar problem occurs when op = instanceof. We want to put a space
around the operands so that these cases are properly evaluated as an
expression.
